### PR TITLE
校验规则升级

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -94,6 +94,8 @@
             "type": "/^(?!application\/(ld\\+)?json)/",
             "src":"/^(?!((http(s)?:)?\/\/mipcache.bdstatic.com)|((http(s)?:)?\/\/m.baidu.com\/static\/ala\/sf\/static\/))/"
         }
+    }, {
+        "disallowed_ancestor": "template"
     }],
     "mip-input": {
         "mandatory_ancestor": "mip-form",
@@ -152,13 +154,6 @@
 
     "a": {
         "attrs": {
-            "target": {
-                "mandatory": true,
-                "value": "/^_blank$/",
-                "match": {
-                    "href": "/^((http(s)?:)?\/\/)|#$/"
-                }
-            },
             "href": {
                 "mandatory": true,
                 "value": "/^((http(s)?:)?\/\/)|#|(tel:\\d+[\\d-]*)$|(sms:\\d+)$|(mailto:([a-zA-Z0-9_\\.\\-])+\\@(([a-zA-Z0-9\\-])+\\.)+([a-zA-Z0-9]{2,4})+)/"
@@ -297,6 +292,13 @@
         "duplicate": true,
         "mandatory_parent": "head"
         
+    },
+    "templage": {
+        "attrs": {
+            "type": {
+                 "mandatory": true
+            }
+        }
     }
     
 }

--- a/rules.json
+++ b/rules.json
@@ -217,7 +217,10 @@
             },
             "src": {
                 "mandatory": true,
-                "value": "/^http(s)?:\/\//"
+                "value": "/^http(s)?:\/\//",
+                "match": {
+                    "tpl": "imageText"
+                }
             },
             "texttip": {
                 "mandatory": true,
@@ -293,7 +296,7 @@
         "mandatory_parent": "head"
         
     },
-    "templage": {
+    "template": {
         "attrs": {
             "type": {
                  "mandatory": true


### PR DESCRIPTION
- template标签强制有type属性
- script标签的祖先节点不能有template标签
- 去掉 a 标签 target=‘_blank’的属性值强制